### PR TITLE
Add testcase for decoding query with pointer field.

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -45,7 +45,8 @@ func TestDecodeQuery(t *testing.T) {
 			Name           string `oas:"name"`
 			Sex            string `oas:"sex"`
 			fieldWithNoTag string
-			notSettable    string `oas:"not_settable"`
+			notSettable    string  `oas:"not_settable"`
+			NotMandatory   *string `oas:"not_mandatory"`
 		}
 
 		member struct {
@@ -55,6 +56,8 @@ func TestDecodeQuery(t *testing.T) {
 			Height      float32 `oas:"height"`
 		}
 	)
+
+	String := func(s string) *string { return &s }
 
 	number := 1
 
@@ -297,6 +300,27 @@ func TestDecodeQuery(t *testing.T) {
 			expectedError: fmt.Errorf(
 				"field notSettable of type user is not settable",
 			),
+		},
+		{
+			// Pointer field
+			ps: []spec.Parameter{
+				{
+					ParamProps: spec.ParamProps{
+						Name: "not_mandatory",
+						In:   "query",
+					},
+					SimpleSchema: spec.SimpleSchema{
+						Type: "string",
+					},
+				},
+			},
+			q: url.Values{
+				"not_mandatory": []string{"I can be nil"},
+			},
+			dst: &user{},
+			expectedData: &user{
+				NotMandatory: String("I can be nil"),
+			},
 		},
 	}
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -182,7 +182,7 @@ func TestDecodeQuery(t *testing.T) {
 			expectedData: &user{
 				Name: "John",
 			},
-			expectedError: fmt.Errorf("field Sex is not assignable to int"),
+			expectedError: fmt.Errorf("value of type int is not assignable to field Sex of type string"),
 		},
 		{
 			// Different types of query parameters


### PR DESCRIPTION
This test currently fails with the following output:
```
$ go test
--- FAIL: TestDecodeQuery (0.00s)
        decode_test.go:330: Expected error to be <nil> but got field NotMandatory is not assignable to string
        decode_test.go:334: Expected dst to be &{    0xc4202a4a00} but got &{    <nil>}
FAIL
exit status 1
FAIL    oas2    15.418s
```
Obviously I can't have query structures with pointer fields, therefore there is no way to distinguish if empty string came from request or was set as a zero value for the string field.