### PR TITLE
Expose WithOperation function

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -28,12 +28,13 @@ type operationMiddleware struct {
 
 func (m operationMiddleware) Apply(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		req = withOperation(req, m.operation)
+		req = WithOperation(req, m.operation)
 		next.ServeHTTP(w, req)
 	})
 }
 
-func withOperation(req *http.Request, op *spec.Operation) *http.Request {
+// WithOperation returns request with context value defining *spec.Operation.
+func WithOperation(req *http.Request, op *spec.Operation) *http.Request {
 	return req.WithContext(
 		context.WithValue(req.Context(), contextKeyOperation{}, op),
 	)

--- a/operation_test.go
+++ b/operation_test.go
@@ -27,7 +27,7 @@ func TestMustOperation(t *testing.T) {
 		}
 
 		op := &spec.Operation{OperationProps: spec.OperationProps{Description: "some"}}
-		req = withOperation(req, op)
+		req = WithOperation(req, op)
 
 		actualOperation := MustOperation(req)
 		if !reflect.DeepEqual(actualOperation, op) {


### PR DESCRIPTION
Make function `WithOperation()` public so it can be used to manually add operation to request. It may be useful in tests when you don't want to parse the full spec file.