### PR TITLE
Add middleware options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- New feature: It is now possible to pass additional options to middlewares.
+In particular, the first available option is to provide Content-Type selectors
+to validators.
+
 ## [0.5.1] - 2018-03-14
 
 ### Fixed

--- a/middleware_options.go
+++ b/middleware_options.go
@@ -1,0 +1,34 @@
+package oas
+
+import "regexp"
+
+var (
+	contentTypeSelectorRegexJSON    *regexp.Regexp
+	contentTypeSelectorRegexJSONAPI *regexp.Regexp
+)
+
+func init() {
+	contentTypeSelectorRegexJSON = regexp.MustCompile(`^application\/json`)
+	contentTypeSelectorRegexJSONAPI = regexp.MustCompile(`^application\/vnd\.api\+json$`)
+}
+
+// MiddlewareOptions represent options for middleware.
+type MiddlewareOptions struct {
+	contentTypeRegexSelectors []*regexp.Regexp
+}
+
+// MiddlewareOption represent option for middleware.
+type MiddlewareOption func(*MiddlewareOptions)
+
+// ContentTypeRegexSelector select requests/responses based on Content-Type
+// header. If any selector matches Content-Type of the request/response, then it
+// will be validated. Otherwise, validator skips validation of the request/response.
+//
+// This options can be applied to the following middlewares:
+// - BodyValidator
+// - ResponseBodyValidator
+func ContentTypeRegexSelector(selector *regexp.Regexp) MiddlewareOption {
+	return func(opts *MiddlewareOptions) {
+		opts.contentTypeRegexSelectors = append(opts.contentTypeRegexSelectors, selector)
+	}
+}

--- a/request_body_validator_test.go
+++ b/request_body_validator_test.go
@@ -16,7 +16,14 @@ func TestBodyValidator(t *testing.T) {
 		"addPet": http.HandlerFunc(handleAddPet),
 	}
 	errHandler := makeErrorHandler()
-	router, err := NewRouter(loadDoc(petstore).Spec(), handlers, Use(BodyValidator(errHandler)))
+
+	bv := BodyValidator(errHandler, ContentTypeRegexSelector(contentTypeSelectorRegexJSON))
+
+	router, err := NewRouter(
+		loadDoc(petstore).Spec(),
+		handlers,
+		Use(bv),
+	)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}


### PR DESCRIPTION
It is now possible to pass additional options to middlewares.
In particular, the first available option is to provide Content-Type
selectors to validators.