### PR TITLE
Rework DecodeQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,14 @@ And populate it:
 
 ```go
 var m Member 
-oas.DecodeQuery(paramSpec, req.URL.Query(), &m)
+oas.DecodeQuery(req, &m)
 
 fmt.Printf("%#v", m) // Member{Name:"John", Age:27, LovesApples:true}
 ```
 
-See [`godoc example`](https://godoc.org/github.com/hypnoglow/oas2#example-DecodeQuery) for complete example code.
+Note that it works only with oas router, because it needs to extract operation
+spec from the request. To use custom parameters spec, use `oas.DecodeQueryParams()`.
+See [`godoc example`](https://godoc.org/github.com/hypnoglow/oas2#example-DecodeQueryParams) for details.
 
 ### Pluggable formats & validators
 

--- a/decode.go
+++ b/decode.go
@@ -1,7 +1,9 @@
 package oas
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"reflect"
 
@@ -14,8 +16,18 @@ const (
 	tag = "oas"
 )
 
-// DecodeQuery decodes query parameters by their spec to the dst.
-func DecodeQuery(ps []spec.Parameter, q url.Values, dst interface{}) error {
+// DecodeQuery decodes all query params by request operation spec to the dst.
+func DecodeQuery(req *http.Request, dst interface{}) error {
+	op := GetOperation(req)
+	if op == nil {
+		return errors.New("request has no operation in its context")
+	}
+
+	return DecodeQueryParams(op.Parameters, req.URL.Query(), dst)
+}
+
+// DecodeQueryParams decodes query parameters by their spec to the dst.
+func DecodeQueryParams(ps []spec.Parameter, q url.Values, dst interface{}) error {
 	dv := reflect.ValueOf(dst)
 	if dv.Kind() != reflect.Ptr {
 		return fmt.Errorf("dst is not a pointer to struct (cannot modify)")

--- a/decode_test.go
+++ b/decode_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-openapi/spec"
 )
 
-func ExampleDecodeQuery() {
+func ExampleDecodeQueryParams() {
 	// In real app parameters will be taken from spec document (yaml or json).
 	params := []spec.Parameter{
 		*spec.QueryParam("name").Typed("string", ""),
@@ -29,7 +29,7 @@ func ExampleDecodeQuery() {
 	}
 
 	var m member
-	if err := DecodeQuery(params, query, &m); err != nil {
+	if err := DecodeQueryParams(params, query, &m); err != nil {
 		panic(err)
 	}
 
@@ -39,7 +39,7 @@ func ExampleDecodeQuery() {
 	// oas.member{Name:"John", Age:27, LovesApples:true}
 }
 
-func TestDecodeQuery(t *testing.T) {
+func TestDecodeQueryParams(t *testing.T) {
 	type (
 		// nolint: megacheck
 		user struct {
@@ -326,7 +326,7 @@ func TestDecodeQuery(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		err := DecodeQuery(c.ps, c.q, c.dst)
+		err := DecodeQueryParams(c.ps, c.q, c.dst)
 		if !reflect.DeepEqual(c.expectedError, err) {
 			t.Errorf("Expected error to be %v but got %v", c.expectedError, err)
 		}


### PR DESCRIPTION
DecodeQuery now accepts request and extracts operation spec from it.
Old function is renamed to DecodeQueryParams.