### PR TITLE
Fix operation paths

### DIFF
--- a/router.go
+++ b/router.go
@@ -57,7 +57,11 @@ func NewRouter(
 		case SpecHandlerTypeStatic:
 			specHandler = StaticSpecHandler(doc.OrigSpec())
 		}
-		router.baseRouter.Route(http.MethodGet, doc.Spec().BasePath, specHandler)
+		path := doc.Spec().BasePath
+		if path == "" {
+			path = "/"
+		}
+		router.baseRouter.Route(http.MethodGet, path, specHandler)
 	}
 
 	for method, pathOps := range analysis.New(doc.Spec()).Operations() {


### PR DESCRIPTION
I've got a problem with `basePath` in spec. I need it to be empty (or `/`). If I delete it from spec file, the program fails with this
```
panic: chi: routing pattern must begin with '/' in ''

goroutine 1 [running]:
go.fasten.cloud/geo/explorer/vendor/github.com/go-chi/chi.(*Mux).handle(0xc42027e000, 0x8, 0x0, 0x0, 0xbeffa0, 0xc4200aa038, 0xc420f9d5f0)
	/home/dkrivak/Dev/projects/go/src/go.fasten.cloud/geo/explorer/vendor/github.com/go-chi/chi/mux.go:375 +0x2a4
go.fasten.cloud/geo/explorer/vendor/github.com/go-chi/chi.(*Mux).Method(0xc42027e000, 0xb63ff4, 0x3, 0x0, 0x0, 0xbeffa0, 0xc4200aa038)
	/home/dkrivak/Dev/projects/go/src/go.fasten.cloud/geo/explorer/vendor/github.com/go-chi/chi/mux.go:117 +0xb3
go.fasten.cloud/geo/explorer/vendor/github.com/hypnoglow/oas2.chiRouter.Route(0xc00020, 0xc42027e000, 0xb63ff4, 0x3, 0x0, 0x0, 0xbeffa0, 0xc4200aa038)
	/home/dkrivak/Dev/projects/go/src/go.fasten.cloud/geo/explorer/vendor/github.com/hypnoglow/oas2/router_adapter.go:23 +0x70
go.fasten.cloud/geo/explorer/vendor/github.com/hypnoglow/oas2.NewRouter(0xc4200aa018, 0xc420f9dc50, 0xc420f9dc80, 0x6, 0x6, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/dkrivak/Dev/projects/go/src/go.fasten.cloud/geo/explorer/vendor/github.com/hypnoglow/oas2/router.go:60 +0x1be
...
```

And when `basePath: /`, then I get double slashes in paths
```
DEBU[0000] oas: handle DELETE //cities/{id}              channel=oas
DEBU[0000] oas: handle DELETE //locations/{id}           channel=oas
DEBU[0000] oas: handle DELETE //streets/{id}             channel=oas
...
```